### PR TITLE
Repos Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,11 +39,11 @@
 			<h2 class="project-tagline">A Tech Meetup and Community for Polyglots in Tech Valley</h2>
 		</section>
 		<section class="main-content">
-			<h3>Next Meetup: Downloading Videos from a XML/JSON Feed with Node and Elixir</h3>
+			<h3>Next Meetup: TBD</h3>
 
-			<p><strong>When:</strong> Tuesday, October 27, 2015 @ 5:30 PM<br /><strong>Where:</strong> MadGlory Office, Saratoga Springs, NY</p>
+			<p><strong>When:</strong> TBD<br /><strong>Where:</strong> MadGlory Office, Saratoga Springs, NY</p>
 
-			<p><a href="https://github.com/agnostechvalley/agnostechvalley.github.io/issues/2">More Details</a></p>
+			<p><a href="/repos">Past Meetup Repos</a></p>
 
 			<hr />
 

--- a/repos/index.html
+++ b/repos/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en-us">
+	<head>
+		<meta charset="UTF-8">
+		<title>AgnosTechValley</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="stylesheet" type="text/css" href="stylesheets/normalize.css" media="screen">
+		<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+		<link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
+		<link rel="stylesheet" type="text/css" href="stylesheets/github-light.css" media="screen">
+		<meta property="og:title" content="AgnosTechValley: Repos" />
+		<meta property="og:site_name" content="AgnosTechValley" />
+		<meta property="og:type" content="website" />
+		<meta property="og:description" content="All of the repos from past meetups." />
+		<meta property="og:url" content="http://agnostechvalley.com/" />
+		<meta property="og:image" content="http://agnostechvalley.com/images/code.png" />
+
+		<link rel="apple-touch-icon" sizes="57x57" href="/images/favicon/apple-icon-57x57.png">
+		<link rel="apple-touch-icon" sizes="60x60" href="/images/favicon/apple-icon-60x60.png">
+		<link rel="apple-touch-icon" sizes="72x72" href="/images/favicon/apple-icon-72x72.png">
+		<link rel="apple-touch-icon" sizes="76x76" href="/images/favicon/apple-icon-76x76.png">
+		<link rel="apple-touch-icon" sizes="114x114" href="/images/favicon/apple-icon-114x114.png">
+		<link rel="apple-touch-icon" sizes="120x120" href="/images/favicon/apple-icon-120x120.png">
+		<link rel="apple-touch-icon" sizes="144x144" href="/images/favicon/apple-icon-144x144.png">
+		<link rel="apple-touch-icon" sizes="152x152" href="/images/favicon/apple-icon-152x152.png">
+		<link rel="apple-touch-icon" sizes="180x180" href="/images/favicon/apple-icon-180x180.png">
+		<link rel="icon" type="image/png" sizes="192x192"  href="/images/favicon/android-icon-192x192.png">
+		<link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png">
+		<link rel="icon" type="image/png" sizes="96x96" href="/images/favicon/favicon-96x96.png">
+		<link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png">
+		<link rel="manifest" href="/images/favicon/manifest.json">
+		<meta name="msapplication-TileColor" content="#ffffff">
+		<meta name="msapplication-TileImage" content="/images/favicon/ms-icon-144x144.png">
+		<meta name="theme-color" content="#ffffff">
+	</head>
+	<body>
+		<section class="page-header">
+			<h1 class="project-name">AgnosTechValley: Repos</h1>
+			<h2 class="project-tagline">A Tech Meetup and Community for Polyglots in Tech Valley</h2>
+		</section>
+		<section class="main-content">
+			<h3>October 27, 2015: Downloading Videos from a XML/JSON Feed with Node and Elixir</h3>
+
+			<ul>
+				<li><a href="https://github.com/agnostechvalley/episode-fetcher-elixir">agnostechvalley/episode-fetcher-elixir</a> by <a href="https://github.com/rjsamson">@rjsamson</a></li>
+				<li><a href="https://github.com/agnostechvalley/episode-fetcher-node">agnostechvalley/episode-fetcher-node</a> by <a href="https://github.com/brkattk">@brkattk</a></li>
+			</ul>
+
+			<footer class="site-footer">
+				<span class="site-footer-credits"><a href="https://github.com/agnostechvalley">GitHub</a> and <a href="https://twitter.com/agnostechvalley">Twitter</a>.</span>
+			</footer>
+
+		</section>
+	</body>
+</html>

--- a/repos/index.html
+++ b/repos/index.html
@@ -39,6 +39,15 @@
 			<h2 class="project-tagline">A Tech Meetup and Community for Polyglots in Tech Valley</h2>
 		</section>
 		<section class="main-content">
+			<h3>November 24, 2015: More XML/JSON Feed Parsing in Rust and npm for Scripting</h3>
+
+			<ul>
+				<li><a href="https://github.com/agnostechvalley/npm-for-scripting">agnostechvalley/npm-for-scripting</a> by <a href="https://github.com/blainsmith">@blainsmith</a></li>
+				<li><a href="https://github.com/doon/podcastsucker">doon/podcastsucker</a> by <a href="https://github.com/doon">@doon</a></li>
+			</ul>
+
+			<hr />
+
 			<h3>October 27, 2015: Downloading Videos from a XML/JSON Feed with Node and Elixir</h3>
 
 			<ul>


### PR DESCRIPTION
What do you think about a page listing past meetups with references to the repos. Future presenters can make PRs against this and add theirs to the list.

Going to make an issue to make this public site templated soon so we don't have to copy/pasta all the HTMLs all the time.